### PR TITLE
Update 2023-09-30 1107H | Fixes and updates

### DIFF
--- a/languages/python/CHANGELOGS.md
+++ b/languages/python/CHANGELOGS.md
@@ -2,7 +2,8 @@
 
 ## Table of Contents
 > version | date        time | status
-+ v0.1.0  | 2023-09-28 0846H | Development
++ v0.1.0  | 2023-09-28 0846H | Pushed to main
++ v0.2.0  | 2023-09-30 1104H | Development; Testing
 
 ## Entries
 ### v0.1.0
@@ -12,4 +13,17 @@
     + Added dependency: python package 'pyyaml' for YAML file management
 - Updates
     + Changed dependency: python package 'pyyaml' => 'ruamel.yaml'
+
+### v0.2.0
+- Updates
+    - Additions
+        + Added function 'convert_json_to_yaml()' corresponding to the yaml to json alternative
+    - Moved
+        + Moved the lines in main into a standalone function 'convert_yaml_to_json()'
+    - Renames
+        + Renamed 'YAML', 'TOML' and 'JSON' classes into 'YAMLConfig', 'TOMLConfig', and 'JSONConfig' class respectively
+    - Removal
+        + Removed the 'as yaml' label when importing YAML, and initialized 'yaml' as class variable in the YAMLConfigs class instead
+    - Fixes
+        + Fixed bug where dumping of Dictionary Object via '.write_config()' will throw an error
 

--- a/languages/python/src/lib/configs.py
+++ b/languages/python/src/lib/configs.py
@@ -6,7 +6,7 @@ import sys
 import json
 
 ## External Libraries
-from ruamel.yaml import YAML as yaml
+from ruamel.yaml import YAML
 from ruamel.yaml.main import round_trip_load as yaml_load, round_trip_dump as yaml_dump
 
 ## Get system information
@@ -75,7 +75,7 @@ class Configuration:
             file_exists = True
         return file_exists
 
-class YAML(Configuration):
+class YAMLConfig(Configuration):
     """
     YAML Configuration File Handler
     inheriting the configuration file class
@@ -85,10 +85,17 @@ class YAML(Configuration):
         Class constructor
         """
         ## To keep the inheritance of the parent's __init__() function
-        super(YAML, self).__init__(file_name, "yaml", mode)
+        super(YAMLConfig, self).__init__(file_name, "yaml", mode)
         self.configuration = Configuration
+
+        # Initialize Classes
+        self.yaml = YAML()
+
+        # Set properties
         self.set_filename(file_name)
         self.set_mode(mode)
+
+        # Initialize Variables
         self.file = None
 
     def set_filename(self, file_name):
@@ -120,14 +127,25 @@ class YAML(Configuration):
             self.file.close()
             self.file = None
 
+    def convert_dict_to_yaml(self, data):
+        """
+        Convert a dictionary object to YAML file
+
+        :: Params
+        - data : The dictionary object you wish to convert
+            Type: Dictionary
+        """
+        return self.yaml.dump(data)
+
     def write_config(self, data):
         """
         Dump and write dictionary object to YAML configuration file
         """
+        print("Data: {}, Type: {}".format(data, type(data)))
         # Check if data is not empty and file is opened
         if (data != None) and (self.file != None):
             # Dump the data
-            yaml.dump(data, self.file)
+            self.yaml.dump(data, self.file)
 
     def read_config(self):
         """
@@ -150,7 +168,7 @@ class YAML(Configuration):
             return yaml_load(yaml_str)
 
 
-class TOML(Configuration):
+class TOMLConfig(Configuration):
     """
     TOML Configuration File 
     inheriting the configuration file class
@@ -160,12 +178,12 @@ class TOML(Configuration):
         Constructor
         """
         ## To keep the inheritance of the parent's __init__() function
-        super(TOML, self).__init__(file_name, "toml", mode)
+        super(TOMLConfig, self).__init__(file_name, "toml", mode)
 
         # Initialize Variables
         self.configuration = Configuration
 
-class JSON(Configuration):
+class JSONConfig(Configuration):
     """
     JSON Configuration File 
     inheriting the configuration file class
@@ -175,7 +193,7 @@ class JSON(Configuration):
         Constructor
         """
         ## To keep the inheritance of the parent's __init__() function
-        super(JSON, self).__init__(file_name, "json", mode)
+        super(JSONConfig, self).__init__(file_name, "json", mode)
 
         # Initialize Variables
         self.configuration = Configuration

--- a/languages/python/src/main.py
+++ b/languages/python/src/main.py
@@ -12,7 +12,7 @@ import sys
 
 ## External Libraries
 import lib.configs as configs
-from lib.configs import YAML, JSON, Dictionary
+from lib.configs import YAMLConfig, JSONConfig, Dictionary
 
 def setup():
     """
@@ -24,8 +24,8 @@ def setup():
     json_cfg_filename = "data.json"
 
     # Initialize Classes
-    cs_Yaml = YAML(yaml_cfg_filename)
-    cs_JSON = JSON(json_cfg_filename, "w+")
+    cs_Yaml = YAMLConfig(yaml_cfg_filename)
+    cs_JSON = JSONConfig(json_cfg_filename)
     cs_Dict = Dictionary()
 
 def print_yaml(yaml_Contents):
@@ -45,7 +45,7 @@ def print_yaml(yaml_Contents):
                 for k,v in v.items():
                     print("\t{}".format(v))
 
-def main():
+def convert_yaml_to_json():
     """
     Open, read, print and close YAML configuration file
     """
@@ -70,6 +70,7 @@ def main():
     """
     print("Writing Dictionary object to JSON file...")
     # Open file and write the dictionary object to JSON
+    cs_JSON.set_mode("w+")
     cs_JSON.open_file()
     cs_JSON.write_config(yaml_Contents)
     # Close file after usage
@@ -91,6 +92,65 @@ def main():
 
     # Print JSON contents
     print(json_Contents)
+
+def convert_json_to_yaml():
+    """
+    Open, read, print and close JSON configuration file
+    """
+    print("===================================")
+    print(" Converting JSON file [{}] => [{}] ".format(json_cfg_filename, yaml_cfg_filename))
+    print("===================================")
+
+    print("")
+
+    print("Reading JSON Configuration file...")
+    cs_JSON.open_file()
+    json_Contents = cs_JSON.read_config()
+    # Close file after usage
+    cs_JSON.close_file()
+
+    # Print YAML contents
+    print_yaml(json_Contents)
+
+    print("")
+
+    """
+    Take JSON config file and output as YAML
+    """
+    print("Writing Dictionary object to YAML file...")
+    # Set new file name
+    cs_Yaml.set_filename("data2.yaml")
+    # Set file write mode to Write+Read
+    cs_Yaml.set_mode("w+")
+    # Open file and write the dictionary object to JSON
+    cs_Yaml.open_file()
+    cs_Yaml.write_config(json_Contents)
+    # Close file after usage
+    cs_Yaml.close_file()
+
+    print("")
+
+    print("(+) Successfully converted JSON file [{}] => YAML file [{}]".format(json_cfg_filename, yaml_cfg_filename))
+
+    print("")
+
+    print("Reading newly created YAML file...")
+    # Set new file name
+    cs_Yaml.set_filename("data2.yaml")
+    # Set file to read and open file and read contents
+    cs_Yaml.set_mode("r")
+    # Open file and write the dictionary object to JSON
+    cs_Yaml.open_file()
+    yaml_Contents = cs_Yaml.read_config()
+    # Close file after usage
+    cs_Yaml.close_file()
+
+    # Print JSON contents
+    print(yaml_Contents)
+
+def main():
+    convert_yaml_to_json()
+    convert_json_to_yaml()
 
 if __name__ == "__main__":
     setup()


### PR DESCRIPTION
- Updates
    - Additions
        + Added function 'convert_json_to_yaml()' corresponding to the yaml to json alternative
    - Moved
        + Moved the lines in main into a standalone function 'convert_yaml_to_json()'
    - Renames
        + Renamed 'YAML', 'TOML' and 'JSON' classes into 'YAMLConfig', 'TOMLConfig', and 'JSONConfig' class respectively
    - Removal
        + Removed the 'as yaml' label when importing YAML, and initialized 'yaml' as class variable in the YAMLConfigs class instead
    - Fixes
        + Fixed bug where dumping of Dictionary Object via '.write_config()' will throw an error